### PR TITLE
Init the contributing.md for ot/spec.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+CONTRIBUTING
+============
+
+Contributions are always welcome, no matter how large or small. Before contributing, you should know, this repository is a place to document Official OpenTracing Specification, so, OpenTracing team will **treat all Contributions very carefully**.
+
+### Understand Specification
+First of all, as contributing a Specification, you should fully understand all `Concepts and Terminology`, `OpenTracing APIs` and `Best Practices`, which you can find at http://opentracing.io/documentation/
+
+### Submit an issue
+Submit an issue, which describes your backgroud story, proposal etc., and discuss with OpenTracing Team Members.
+
+The proposal includes(but not limited) new Concept, Terminology, Mechanism, APIs, even new span-tag-key or span-log-key.
+
+### Send pull request
+After discussion, if OpenTracing Team has accepted your proposal, you can fork the repo, and send a pull request, which should link to the prev issue.
+
+### Request for review
+In the Specification, all description should ensure **accurate**, ask OpenTracing Team Members to review your pull request. And there will be more discussion.
+
+---
+[OpenTracing Team Members List]( http://opentracing.io/documentation/pages/authors-and-contributors.html)


### PR DESCRIPTION
Add a statement about `How about the contribution and governance model` from gitter. Although the OpenTracing Team Members List is out-of-date.

>at this point I have a reasonable sense of which people typically care about which sorts of things
maybe it’s time to do something more formal… /shrug, open to opinions.

I think this is the first step. And we should set a formal **OpenTracing Team Members List**.

If there is any English-language issue, please help me fix them. 😝  