### PR TITLE
First draft of a more formal OT organization

### DIFF
--- a/project_organization.md
+++ b/project_organization.md
@@ -1,0 +1,50 @@
+## Industrial Advisory Board
+
+OpenTracing has an **Industrial Advisory Board** (IAB) that comprises engineers with detailed knowledge of tracing technology at companies of different scales and software maturity. The Specification Shepherds engage with the IAB on a periodic basis to gather feedback about successes, challenges, and open-source packages which would benefit from greater OpenTracing support.
+
+## Contributed OpenTracing Support
+
+Repositories under [github.com/opentracing-contrib](https://github.com/opentracing-contrib) pertain to specific open-source software packages and projects. Each may have its own owners and internal policies regarding PRs, review requirements, and committer management.
+
+# OpenTracing Project Organization
+
+[OpenTracing](http://opentracing.io) is essentially a standardization effort. There are three constituencies that care about this standard:
+
+1. **Tracing tool maintainers:** "Instrumenting all software" is an unreasonable goal for any one particular tracing or monitoring project or vendor. OpenTracing essentially amortizes this work.
+2. **Software developers who build and deploy applications:** These developers want to use whatever tracing and observability tools that work best within their organization's infrastructure, and they want to choose those tools independent of whatever third-party (open-source) software packages they happen to have built around.
+3. **Software developers who contribute to widely-used software:** Inasmuch as this software needs to exist within a microservices deployment, it must integrate with whatever tracing tool(s) its diverse users already depend on.
+
+OpenTracing's project organization makes room for each of these constituencies.
+
+## OpenTracing Specification Council (OTSC)
+
+The authors of any tracing or observability tool that supports OpenTracing are **always** invited to contribute to discussions about the future of OpenTracing as a standard. OpenTracing endeavors to maintain a list of such authors and will occasionally solicit feedback from that group.
+
+A subset of these tracing system authors are part of the **OpenTracing Specification Council** (OTSC). Said council members have write access across the [github.com/opentracing](https://github.com/opentracing) and [github.com/opentracing-contrib](https://github.com/opentracing-contrib) organizations (though other individuals may also have write access to specific repos within those organizations). Each OTSC member represents a tracing system which has substantial institutional support (and thus longevity). The current OpenTracing Specification Council is as follows (in alphabetical order):
+
+- Bas van Beek ([@basvanbeek](https://github.com/basvanbeek)): Zipkin
+- Ben Sigelman ([@bensigelman](https://github.com/bensigelman)): LightStep
+- Pavol Loffay ([@pavolloffay](https://github.com/pavolloffay)): Hawkular
+- Yuri Shkuro ([@yurishkuro](https://github.com/yurishkuro)): Jaeger
+
+OTSC members have the following primary responsibilities:
+
+- Define priorities for OpenTracing as a project and standard
+- Accurately represent the concerns and needs of downstream tracing and observability tools
+- Strategize around possible third-party package integrations
+- Weigh in and offer tie-breaking votes for issues where consensus among the larger community has proven elusive
+
+## OpenTracing Industrial Advisory Board (OTIAB)
+
+OpenTracing has an **Industrial Advisory Board** (OTIAB) that comprises engineers with detailed knowledge of tracing technology at companies of different scales and software maturity. The OTSC members engage with the OTIAB on a periodic basis to gather feedback about successes, challenges, and open-source packages which would benefit from greater OpenTracing support.
+
+OTIAB members have the following primary responsibilities:
+
+- Participate in periodic (but infrequent: monthly or less) calls with the OTSC
+- Describe and rationalize tracing and observability challenges within their own companies
+- Provide feedback about possible priorities and/or specific proposals from the OTSC
+- Represent OpenTracing’s interests within their own organizations
+
+## Contributed OpenTracing Support
+
+Repositories under [github.com/opentracing-contrib](https://github.com/opentracing-contrib) pertain to specific open-source software packages and projects. Each may have its own owners and internal policies regarding PRs, review requirements, and committer management. You can learn more about OpenTracing contributions via the [opentracing-contrib meta-repository](https://github.com/opentracing-contrib/meta).

--- a/project_organization.md
+++ b/project_organization.md
@@ -15,7 +15,7 @@ The authors of any tracing or observability tool that supports OpenTracing are *
 A subset of these tracing system authors are part of the **OpenTracing Specification Council** (OTSC). Said council members have write access across the [github.com/opentracing](https://github.com/opentracing) and [github.com/opentracing-contrib](https://github.com/opentracing-contrib) organizations (though other individuals may also have write access to specific repos within those organizations). Each OTSC member represents a tracing system which has substantial institutional support (and thus longevity). The current OpenTracing Specification Council is as follows (in alphabetical order):
 
 - Bas van Beek ([@basvanbeek](https://github.com/basvanbeek)): Zipkin
-- Ben Sigelman ([@bensigelman](https://github.com/bensigelman)): LightStep
+- Ben Sigelman ([@bhs](https://github.com/bensigelman)): LightStep
 - Pavol Loffay ([@pavolloffay](https://github.com/pavolloffay)): Hawkular
 - Yuri Shkuro ([@yurishkuro](https://github.com/yurishkuro)): Jaeger
 

--- a/project_organization.md
+++ b/project_organization.md
@@ -1,11 +1,3 @@
-## Industrial Advisory Board
-
-OpenTracing has an **Industrial Advisory Board** (IAB) that comprises engineers with detailed knowledge of tracing technology at companies of different scales and software maturity. The Specification Shepherds engage with the IAB on a periodic basis to gather feedback about successes, challenges, and open-source packages which would benefit from greater OpenTracing support.
-
-## Contributed OpenTracing Support
-
-Repositories under [github.com/opentracing-contrib](https://github.com/opentracing-contrib) pertain to specific open-source software packages and projects. Each may have its own owners and internal policies regarding PRs, review requirements, and committer management.
-
 # OpenTracing Project Organization
 
 [OpenTracing](http://opentracing.io) is essentially a standardization effort. There are three constituencies that care about this standard:
@@ -44,6 +36,8 @@ OTIAB members have the following primary responsibilities:
 - Describe and rationalize tracing and observability challenges within their own companies
 - Provide feedback about possible priorities and/or specific proposals from the OTSC
 - Represent OpenTracing’s interests within their own organizations
+
+The initial list of OTIAB members will be announced in March 2017.
 
 ## Contributed OpenTracing Support
 

--- a/project_organization.md
+++ b/project_organization.md
@@ -1,6 +1,6 @@
 # OpenTracing Project Organization
 
-[OpenTracing](http://opentracing.io) is essentially a standardization effort. There are three constituencies that care about this standard:
+[OpenTracing](http://opentracing.io) is a standardization effort that makes it easier to consistently model and describe the behavior of transactions in distributed systems. There are three constituencies that care about this standard:
 
 1. **Tracing tool maintainers:** "Instrumenting all software" is an unreasonable goal for any one particular tracing or monitoring project or vendor. OpenTracing essentially amortizes this work.
 2. **Software developers who build and deploy applications:** These developers want to use whatever tracing and observability tools that work best within their organization's infrastructure, and they want to choose those tools independent of whatever third-party (open-source) software packages they happen to have built around.

--- a/project_organization.md
+++ b/project_organization.md
@@ -48,3 +48,10 @@ OTIAB members have the following primary responsibilities:
 ## Contributed OpenTracing Support
 
 Repositories under [github.com/opentracing-contrib](https://github.com/opentracing-contrib) pertain to specific open-source software packages and projects. Each may have its own owners and internal policies regarding PRs, review requirements, and committer management. You can learn more about OpenTracing contributions via the [opentracing-contrib meta-repository](https://github.com/opentracing-contrib/meta).
+
+## Afterword: what's the point of `^^^`?
+
+Sometimes formal governance and acronyms like "OTSC" or "OTIAB" signify hierarchy and exclusion in an open-source effort. The intention with OpenTracing's organization is to do exactly the opposite: by guaranteeing participation from multiple constituencies and multiple software projects and organizations, these simple governance structures aim to bring more ideas to the table. Inasmuch as it's possible, all OpenTracing discussions will take place out in the open and/or at clearly-advertised times and (virtual) places.
+
+If you would like to take on a more formal role on the OTSC or OTIAB, please reach out to an existing OTSC member and we can take it from there.
+

--- a/project_organization.md
+++ b/project_organization.md
@@ -1,6 +1,6 @@
 # OpenTracing Project Organization
 
-[OpenTracing](http://opentracing.io) is a standardization effort that makes it easier to consistently model and describe the behavior of transactions in distributed systems. There are three constituencies that care about this standard:
+[OpenTracing](http://opentracing.io) is a set of standard APIs that consistently model and describe the behavior of distributed systems. There are three constituencies that care about this standard:
 
 1. **Tracing tool maintainers:** "Instrumenting all software" is an unreasonable goal for any one particular tracing or monitoring project or vendor. OpenTracing essentially amortizes this work.
 2. **Software developers who build and deploy applications:** These developers want to use whatever tracing and observability tools that work best within their organization's infrastructure, and they want to choose those tools independent of whatever third-party (open-source) software packages they happen to have built around.
@@ -12,7 +12,7 @@ OpenTracing's project organization makes room for each of these constituencies.
 
 The authors of any tracing or observability tool that supports OpenTracing are **always** invited to contribute to discussions about the future of OpenTracing as a standard. OpenTracing endeavors to maintain a list of such authors and will occasionally solicit feedback from that group.
 
-A subset of these tracing system authors are part of the **OpenTracing Specification Council** (OTSC). Said council members have write access across the [github.com/opentracing](https://github.com/opentracing) and [github.com/opentracing-contrib](https://github.com/opentracing-contrib) organizations (though other individuals may also have write access to specific repos within those organizations). Each OTSC member represents a tracing system which has substantial institutional support (and thus longevity). The current OpenTracing Specification Council is as follows (in alphabetical order):
+A subset of these tracing system authors are part of the **OpenTracing Specification Council** (OTSC). Said council members have write access across the [github.com/opentracing](https://github.com/opentracing) and [github.com/opentracing-contrib](https://github.com/opentracing-contrib) organizations (though other individuals may also have write access to specific repos within those organizations). Each OTSC member represents a tracing system which (a) maintains a public OpenTracing implementation, and (b) has substantial institutional support, and thus longevity. The current OpenTracing Specification Council is as follows (in alphabetical order):
 
 - Bas van Beek ([@basvanbeek](https://github.com/basvanbeek)): Zipkin
 - Ben Sigelman ([@bhs](https://github.com/bensigelman)): LightStep
@@ -32,8 +32,8 @@ OpenTracing has an **Industrial Advisory Board** (OTIAB) that comprises engineer
 
 OTIAB members have the following primary responsibilities:
 
+- Describe and rationalize tracing and observability challenges within their own companies: it is particularly important that they are regularly exposed to instrumentation, integration, and usability issues related to tracing, and further that they are able to effectively distill these concerns and communicate them back to the OTSC
 - Participate in periodic (but infrequent: monthly or less) calls with the OTSC
-- Describe and rationalize tracing and observability challenges within their own companies
 - Provide feedback about possible priorities and/or specific proposals from the OTSC
 - Represent OpenTracing’s interests within their own organizations
 


### PR DESCRIPTION
The .md file in this PR describes a proposed OpenTracing project organization that should do more to formally incorporate feedback from the constituencies that benefit from OT.

I've approached a variety of people about being on the  "Industrial Advisory Board" and they've all said yes... I wanted to get people *outside* of my personal network involved before making the list public.

On a personal note, I am mixed about this. On the one hand, I think some amount of formal governance is necessary (and this is pretty lightweight as far as those things go). On the other, I hate for anyone to feel excluded from, well, anything: decision-making, meetings, etc. The good news is that *they're not*: this is not an exclusionary sort of project organization, it's just a few checks and balances to make it harder for decisions to be made in a vacuum.

Maybe I'll add some of that little screed to the end of the doc, in fact...

Anyway, PTAL. @basvanbeek @pavolloffay @yurishkuro and certainly anyone else who cares about OT at a structural level.