### PR TITLE
Document a peer.address tag

### DIFF
--- a/semantic_conventions.md
+++ b/semantic_conventions.md
@@ -26,6 +26,7 @@ Span tags apply to **the entire Span**; as such, they apply to the entire timera
 | `http.status_code` | integer | HTTP response status code for the associated Span. E.g., 200, 503, 404 |
 | `http.url` | string | URL of the request being handled in this segment of the trace, in standard URI format. E.g., `"https://domain.net/path/to?resource=here"` |
 | `message_bus.destination` | string | An address at which messages can be exchanged. E.g. A Kafka record has an associated `"topic name"` that can be extracted by the instrumented producer or consumer and stored using this tag. |
+| `peer.address` | string | Remote "address", suitable for use in a networking client library. This may be a `"ip:port"`, a bare `"hostname"`, a FQDN, or even a JDBC substring like `"mysql://prod-db:3306"` |
 | `peer.hostname` | string | Remote hostname. E.g., `"opentracing.io"`, `"internal.dns.name"` |
 | `peer.ipv4` | string | Remote IPv4 address as a `.`-separated tuple. E.g., `"127.0.0.1"` |
 | `peer.ipv6` | string | Remote IPv6 address as a string of colon-separated 4-char hex tuples. E.g., `"2001:0db8:85a3:0000:0000:8a2e:0370:7334"` |
@@ -53,7 +54,7 @@ Every Span log has a specific timestamp (which must fall between the start and f
 The following Span tags combine to model RPCs:
 
 - `span.kind`: either `"client"` or `"server"`. It is important to provide this tag **at Span start time**, as it may affect internal ID generation.
-- `peer.hostname`, `peer.ipv4`, `peer.ipv6`, `peer.port`, `peer.service`: optional tags that describe the RPC peer (often in ways it cannot assess internally)
+- `peer.address`, `peer.hostname`, `peer.ipv4`, `peer.ipv6`, `peer.port`, `peer.service`: optional tags that describe the RPC peer (often in ways it cannot assess internally)
 
 ### Message Bus
 
@@ -63,14 +64,14 @@ The following Span tags combine to model message bus based communications:
 
 - `message_bus.destination`: as described in the table above
 - `span.kind`: either `"producer"` or `"consumer"`. It is important to provide this tag **at Span start time**, as it may affect internal ID generation.
-- `peer.hostname`, `peer.ipv4`, `peer.ipv6`, `peer.port`, `peer.service`: optional tags that describe the message bus broker (often in ways it cannot assess internally)
+- `peer.address`, `peer.hostname`, `peer.ipv4`, `peer.ipv6`, `peer.port`, `peer.service`: optional tags that describe the message bus broker (often in ways it cannot assess internally)
 
 ### Database (client) calls
 
 The following Span tags combine to model database calls:
 
 - `db.type`, `db.instance`, `db.user`, and `db.statement`: as described in the table above
-- `peer.hostname`, `peer.ipv4`, `peer.ipv6`, `peer.port`, `peer.service`: optional tags that describe the database peer
+- `peer.address`, `peer.hostname`, `peer.ipv4`, `peer.ipv6`, `peer.port`, `peer.service`: optional tags that describe the database peer
 - `span.kind`: `"client"`
 
 ### Captured errors

--- a/semantic_conventions.yaml
+++ b/semantic_conventions.yaml
@@ -17,6 +17,7 @@ standard_tags:
     'http.status_code': integer
     'http.url': string
     'message_bus.destination': string
+    'peer.address': string
     'peer.hostname': string
     'peer.ipv4': string
     'peer.ipv6': string


### PR DESCRIPTION
Closes #16 

My only question here is whether we want to replace/deprecate the `peer.hostname` and friends. Obviously I voted "no" with this PR, but it's worth thinking about.