### PR TITLE
Update minor version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# History
+
+## 1.1 (2017/03/19)
+
+- Added message bus tags
+- Moved semantic descriptions to `semantic_conventions.md` and `semantic_conventions.yaml`
+- Added OpenTracing governance information to `project_organization.md`
+- Added database tags
+- Added an error log specification
+
+## 1.0 (2016/12/25 🎄)
+
+- Initial release (having moved the content from opentracing.io)

--- a/specification.md
+++ b/specification.md
@@ -1,6 +1,6 @@
 # The OpenTracing Semantic Specification
 
-**Version:** 1.0
+**Version:** 1.1
 
 ## Document Overview
 


### PR DESCRIPTION
There have been a variety of minor backwards-compatible changes to the specification in the past week or two (new tags). As such, the policy is to bump the minor version.

Once this merges I will add a tag for version 1.1.