### PR TITLE
Add log level as a log key

### DIFF
--- a/semantic_conventions.md
+++ b/semantic_conventions.md
@@ -44,9 +44,9 @@ Every Span log has a specific timestamp (which must fall between the start and f
 | `error.kind` | string | The type or "kind" of an error (only for `event="error"` logs). E.g., `"Exception"`, `"OSError"` |
 | `error.object` | object | For languages that support such a thing (e.g., Java, Python), the actual Throwable/Exception/Error object instance itself. E.g., A `java.lang.UnsupportedOperationException` instance, a python `exceptions.NameError` instance |
 | `event` | string | A stable identifier for some notable moment in the lifetime of a Span. For instance, a mutex lock acquisition or release or the sorts of lifetime events in a browser page load described in the [Performance.timing](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceTiming) specification. E.g., from Zipkin, `"cs"`, `"sr"`, `"ss"`, or `"cr"`. Or, more generally, `"initialized"` or `"timed out"`. For errors, `"error"` |
+| `level` | string | Levels used for identifying the severity of an event. Levels are organized from most specific to least: `"FATAL"`(most specific, little data), `"ERROR"`, `"WARN"`, `"INFO"`, `"DEBUG"` and `"TRACE"`(least specific, a lot of data) |
 | `message` | string | A concise, human-readable, one-line message explaining the event. E.g., `"Could not connect to backend"`, `"Cache invalidation succeeded"` |
 | `stack` | string | A stack trace in platform-conventional format; may or may not pertain to an error. E.g., `"File \"example.py\", line 7, in \<module\>\ncaller()\nFile \"example.py\", line 5, in caller\ncallee()\nFile \"example.py\", line 2, in callee\nraise Exception(\"Yikes\")\n"` |
-| `log.priority` | integer | If specified, it must be between 0(included) and 10(included). Higher priority means the log is more important. |
 
 ## Modelling special circumstances
 

--- a/semantic_conventions.md
+++ b/semantic_conventions.md
@@ -44,7 +44,7 @@ Every Span log has a specific timestamp (which must fall between the start and f
 | `error.kind` | string | The type or "kind" of an error (only for `event="error"` logs). E.g., `"Exception"`, `"OSError"` |
 | `error.object` | object | For languages that support such a thing (e.g., Java, Python), the actual Throwable/Exception/Error object instance itself. E.g., A `java.lang.UnsupportedOperationException` instance, a python `exceptions.NameError` instance |
 | `event` | string | A stable identifier for some notable moment in the lifetime of a Span. For instance, a mutex lock acquisition or release or the sorts of lifetime events in a browser page load described in the [Performance.timing](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceTiming) specification. E.g., from Zipkin, `"cs"`, `"sr"`, `"ss"`, or `"cr"`. Or, more generally, `"initialized"` or `"timed out"`. For errors, `"error"` |
-| `level` | string | Levels used for identifying the severity of an event. Levels are organized from most specific to least: `"FATAL"`(most specific, little data), `"ERROR"`, `"WARN"`, `"INFO"`, `"DEBUG"` and `"TRACE"`(least specific, a lot of data) |
+| `level` | string | 4 values: "`error`", "`warn`", "`info`" and "`debug`". |
 | `message` | string | A concise, human-readable, one-line message explaining the event. E.g., `"Could not connect to backend"`, `"Cache invalidation succeeded"` |
 | `stack` | string | A stack trace in platform-conventional format; may or may not pertain to an error. E.g., `"File \"example.py\", line 7, in \<module\>\ncaller()\nFile \"example.py\", line 5, in caller\ncallee()\nFile \"example.py\", line 2, in callee\nraise Exception(\"Yikes\")\n"` |
 

--- a/semantic_conventions.md
+++ b/semantic_conventions.md
@@ -46,6 +46,7 @@ Every Span log has a specific timestamp (which must fall between the start and f
 | `event` | string | A stable identifier for some notable moment in the lifetime of a Span. For instance, a mutex lock acquisition or release or the sorts of lifetime events in a browser page load described in the [Performance.timing](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceTiming) specification. E.g., from Zipkin, `"cs"`, `"sr"`, `"ss"`, or `"cr"`. Or, more generally, `"initialized"` or `"timed out"`. For errors, `"error"` |
 | `message` | string | A concise, human-readable, one-line message explaining the event. E.g., `"Could not connect to backend"`, `"Cache invalidation succeeded"` |
 | `stack` | string | A stack trace in platform-conventional format; may or may not pertain to an error. E.g., `"File \"example.py\", line 7, in \<module\>\ncaller()\nFile \"example.py\", line 5, in caller\ncallee()\nFile \"example.py\", line 2, in callee\nraise Exception(\"Yikes\")\n"` |
+| `log.priority` | integer | If specified, it must be between 0(included) and 10(included). Higher priority means the log is more important. |
 
 ## Modelling special circumstances
 

--- a/specification.md
+++ b/specification.md
@@ -219,6 +219,8 @@ Optional parameters
 
 Note that the OpenTracing project documents certain **["standard log keys"](./semantic_conventions.md)** which have prescribed semantic meanings.
 
+- An integer, represents the log priority. If specified, it must be between 0(included) and 10(included). Higher priority means the log is more important.
+
 #### Set a **baggage** item
 
 Baggage items are key:value string pairs that apply to the given `Span`, its `SpanContext`, and **all `Spans` which directly or transitively _reference_ the local `Span`.** That is, baggage items propagate in-band along with the trace itself.

--- a/specification.md
+++ b/specification.md
@@ -219,8 +219,6 @@ Optional parameters
 
 Note that the OpenTracing project documents certain **["standard log keys"](./semantic_conventions.md)** which have prescribed semantic meanings.
 
-- An integer, represents the log priority. If specified, it must be between 0(included) and 10(included). Higher priority means the log is more important.
-
 #### Set a **baggage** item
 
 Baggage items are key:value string pairs that apply to the given `Span`, its `SpanContext`, and **all `Spans` which directly or transitively _reference_ the local `Span`.** That is, baggage items propagate in-band along with the trace itself.


### PR DESCRIPTION
Relate to https://github.com/opentracing/specification/issues/57.

As we discussed a lot. I think we should add a log priority, to give the tracer implementations more chances to choose, when these are too many logs.