### PR TITLE
Add Chris Erway to the OTSC

### DIFF
--- a/project_organization.md
+++ b/project_organization.md
@@ -16,6 +16,7 @@ A subset of these tracing system authors are part of the **OpenTracing Specifica
 
 - Bas van Beek ([@basvanbeek](https://github.com/basvanbeek)): Zipkin
 - Ben Sigelman ([@bhs](https://github.com/bensigelman)): LightStep
+- Chris Erway ([@cce](https://github.com/cce)): TraceView
 - Pavol Loffay ([@pavolloffay](https://github.com/pavolloffay)): Hawkular
 - Yuri Shkuro ([@yurishkuro](https://github.com/yurishkuro)): Jaeger
 


### PR DESCRIPTION
With https://github.com/tracelytics/go-traceview/pull/35 now merged, TraceView supports OpenTracing. See https://github.com/tracelytics/go-traceview/blob/master/v1/tv/ottv/tracer.go .

Independent of the above, @cce brings a lot of knowledge and experience to the table, esp with the X-Trace school of thought (i.e., "the pure event model").