### PR TITLE
Add DataDog to the OTSC

### DIFF
--- a/project_organization.md
+++ b/project_organization.md
@@ -18,6 +18,7 @@ A subset of these tracing system authors are part of the **OpenTracing Specifica
 - Ben Sigelman ([@bhs](https://github.com/bensigelman)): LightStep
 - Chris Erway ([@cce](https://github.com/cce)): TraceView
 - Erika Arnold ([@erabug](https://github.com/erabug)): New Relic
+- Emanuele Palazzetti ([@palazzem](https://github.com/palazzem)): DataDog
 - Pavol Loffay ([@pavolloffay](https://github.com/pavolloffay)): Hawkular
 - Yuri Shkuro ([@yurishkuro](https://github.com/yurishkuro)): Jaeger
 


### PR DESCRIPTION
Per https://www.datadoghq.com/blog/opentracing-datadog-cncf/ , DataDog has formally announced their OpenTracing support (which has really been happening for quite some time – we are all better off for the contributions of @palazzem, @tylerbenson, @clutchski, and others) and so we are delighted to welcome them here!

I will leave this PR open for a few days, but unless there are objections I will merge mid-week.

cc @opentracing/otsc 