### PR TITLE
Add ISSUE_TEMPLATE to specification (copy of opentracing-php repo)

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,9 +1,9 @@
 <!--
 Welcome to the OpenTracing Specification repo
 
-- Please search for existing issues in order to ensure we don't have duplicate bugs/feature requests.)
-- Please be respectful and considerate of others when commenting on issues)
-- Please provide as much information as possible so we all understand the issue.)
+- Please search for existing issues in order to ensure we don't have duplicate bugs/feature requests.
+- Please be respectful and considerate of others when commenting on issues.
+- Please provide as much information as possible so we all understand the issue.
 - Please don't ask questions here. If you have any question head to our gitter chat https://gitter.im/opentracing/public
 -->
 
@@ -15,7 +15,7 @@ Something that gives context about why this is an issue.
 Describe the problem. If the issue is about an improvement you can skip this. If possible, include a description of the impact of the problem.
 
 ## Proposal
-A proposal that from your POV would solve the problem or improve the existing situation. It should also include the impact.
+A proposal that, from your point of view, would solve the problem or improve the existing situation. It should also include the impact.
 
 ## Questions to address
 Questions that should be answered as outcome of this issue.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -4,7 +4,6 @@ Welcome to the OpenTracing Specification repo
 - Please search for existing issues in order to ensure we don't have duplicate bugs/feature requests.
 - Please be respectful and considerate of others when commenting on issues.
 - Please provide as much information as possible so we all understand the issue.
-- Please don't ask questions here. If you have any question head to our gitter chat https://gitter.im/opentracing/public
 -->
 
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,21 @@
+<!--
+Welcome to the OpenTracing Specification repo
+
+- Please search for existing issues in order to ensure we don't have duplicate bugs/feature requests.)
+- Please be respectful and considerate of others when commenting on issues)
+- Please provide as much information as possible so we all understand the issue.)
+- Please don't ask questions here. If you have any question head to our gitter chat https://gitter.im/opentracing/public
+-->
+
+
+## Background
+Something that gives context about why this is an issue.
+
+## Problem
+Describe the problem. If the issue is about an improvement you can skip this. If possible, include a description of the impact of the problem.
+
+## Proposal
+A proposal that from your POV would solve the problem or improve the existing situation. It should also include the impact.
+
+## Questions to address
+Questions that should be answered as outcome of this issue.


### PR DESCRIPTION
Adds ISSUE_TEMPLATE to specification repo.  This is an (almost) exact copy of the ISSUE_TEMPLATE in [opentracing-php repo](https://github.com/opentracing/opentracing-php/blob/master/.github/ISSUE_TEMPLATE.md)