### PR TITLE
Versioning process for the OpenTracing specification

### DIFF
--- a/rfc_process.md
+++ b/rfc_process.md
@@ -65,7 +65,7 @@ Consensus is used to determine that all of the abstract proposal work has been c
 
 ## Test
 * RFC status changed from `Draft` to `Test`.
-* Release Candidate per major language is created.
+* Release Candidate per supported language is created.
 * API conventions are coordinated between languages.
 * New risks and ambiguities may lead to proposal changes.
 

--- a/rfc_process.md
+++ b/rfc_process.md
@@ -3,13 +3,13 @@ The OpenTracing specification consists of a cross-language, abstract interface, 
 
 In order effect changes to the OpenTracing specification, all interfaces are developed together in a three step process:
 
-* DRAFT: An RFC is drafted to define and justify the desired changes.
-* TEST: A new version of each language interface is designed, tested, and released.
-* ACCEPTED: The abstract interface is versioned to reflect the final changes.
+* **DRAFT:** An RFC is drafted to define and justify the desired changes.
+* **TEST:** A new version of each language interface is designed, tested, and released.
+* **ACCEPTED:** The abstract interface is versioned to reflect the final changes.
 
 # Proposal Components
 
-## RFC (Request for Change)
+## RFC (Request for Comments)
 Proposals begin as a single document, written in markdown and committed to the `/rfc` directory.
 
 An RFC consists of the following:
@@ -47,7 +47,7 @@ Each language interface implements the abstract interface contained in the RFC.
 A complete release candidate consists of the following:
 * Repository branch containing the new version.
 * Packages for installing the new version.
-* Tracers which bind to the new version.
+* More than one tracer which binds to the new version.
 * Major instrumentation ported to the new version.
 
 # Proposal Lifecycle
@@ -69,7 +69,9 @@ Consensus is used to determine that all of the abstract proposal work has been c
 * API conventions are coordinated between languages.
 * New risks and ambiguities may lead to proposal changes.
 
-Once the draft proposal is finalized, language implementation begins. Language maintainers begin creating a release candidate on a branch of the language repository. Links to the release candidates, along with their status, are recorded in the tracking issue.
+Once the draft proposal is finalized, language implementation begins. Language maintainers begin creating a release candidate on a branch of the language repository. Links to the release candidates, along with their status, are recorded in the tracking issue. Multiple tracers create a branch which is compatible with new API, along with important instrumentation libraries. These assest are then used to vet the new API, exploring edge cases and potential issues.
+
+At this stage, issues and further refinements are surfaced and debated via tested examples, as English often is too imprecise to address the finer points of API design.
 
 ## Accepted
 * Remaining language interfaces are released.

--- a/rfc_process.md
+++ b/rfc_process.md
@@ -1,0 +1,83 @@
+# Versioning Process for the OpenTracing Specification
+The OpenTracing specification consists of a cross-language, abstract interface, along with an attendant set of language-specific interfaces. Every interface is versioned, with each language interface supporting a version of the abstract interface.
+
+In order effect changes to the OpenTracing specification, all interfaces are developed together in a three step process:
+
+* DRAFT: An RFC is drafted to define and justify the desired changes.
+* TEST: A new version of each langauage interface is designed, tested, and released.
+* ACCEPTED: The abstract interface is versioned to reflect the final changes.
+
+# Proposal Components
+
+## RFC (Request for Change)
+Proposals begin as a single document, written in markdown and committed to the `/rfc` directory.
+
+An RFC consists of the following:
+
+* Status, date, and author.
+* Problem statement.
+* Historical background.
+* Abstract interface.
+* Use cases.
+* Risk Assesment.
+
+An RFC has the following qualities:
+
+* The issue is clearly defined, and within the scope of the OpenTracing charter.
+* The utility to the OT community is illustrated with concrete use cases. It should be clear not only what will change, but how the new interface is expected to be used.
+* Changes to the abstract interface are clearly defined. Language-specific interfaces will be implemented in a later phase,but the abstract interface must be clear enough that the changes could be ported to many languages without much deviation.
+* All expected behavior should be documented, in sufficient detail such that language-specific tests and examples can be generated from the descriptions.
+* Risks, backwards compatibility, and potential for inconsistency are addressed.
+
+## Tracking Issue
+Often, a proposal will consist of multiple artifacts, such as GitHub issues, pull requests, release candidates, etc. In order to manage these resources, a single, long-running tracking issue is assigned to each proposal.
+
+A tracking issue consists of the following:
+
+* Status, date, and author.
+* Short description of the proposal.
+* A link to the committed RFC.
+* Lists of open issues, PRs, and upcoming deadlines.
+* Links to relevant artifacts, such as release candidates.
+* Links to meetings and other discussion channels.
+
+## Release Candidates
+Each language interface implements the abstract interface contained in the RFC.
+
+A complete release candidate consists of the following:
+* Repository branch containing the new version.
+* Packages for installing the new version.
+* Tracers which bind to the new version.
+* Major instrmentation ported to the new version.
+
+# Proposal Lifecycle
+
+## Draft
+* Pull request to add the draft RFC to `/rfc`. 
+* Tracking issue for the proposal is opened.
+* Debate continues via pull requests against the draft.
+
+A draft proposal is first submitted as a pull request against the specification repository. 
+
+Once there is consensus that the pull request meets the minimum criteria for the beginnings of a draft, and has strong potential to be accepted, the pull request is merged. A tracking issue is created at this point to manage the proposal. The draft RFC is then refined via more pull requests.
+
+Consensus is used to determine that all of the abstract proposal work has been completed, and the investigation should move to language implementations.
+
+## Test
+* RFC status changed from `Draft` to `Test`.
+* Release Candidate per major language is created.
+* API conventions are coordinated between languages.
+* New risks and ambiguities may lead to proposal changes.
+
+Once the draft proposal is finalized, language implementation begins. Language maintainers begin creating a release candidate on a branch of the language repository. Links to the release candidates, along with their status, are recorded in the tracking issue.
+
+## Accepted
+* Remaining language interfaces are released.
+* Abstract interface is versioned and updated.
+* Documentation is updated.
+* RFC status changed from `Test` to `Accepted`.
+* Tracking issue for the proposal is closed.
+
+After a quorum of language interfaces have been tested and released, consensus may be reached that a proposal has been finalized. At this point, the abstract interface contained in the `specification.md` document is updated to reflect the final changes, based on the language in the RFC docment and release candidates.
+
+In addition to the specification, the OpenTracing website and other major docmentation efforts are updated at this time to reflect the latest version. Once all work is complete, the tracking issue is closed.

--- a/rfc_process.md
+++ b/rfc_process.md
@@ -14,7 +14,7 @@ Proposals begin as a single document, written in markdown and committed to the `
 
 An RFC consists of the following:
 
-* Status, date, and author.
+* Title, status, and author.
 * Problem statement.
 * Historical background.
 * Abstract interface.
@@ -34,7 +34,7 @@ Often, a proposal will consist of multiple artifacts, such as GitHub issues, pul
 
 A tracking issue consists of the following:
 
-* Status, date, and author.
+* Title, status, and author.
 * Short description of the proposal.
 * A link to the committed RFC.
 * Lists of open issues, PRs, and upcoming deadlines.

--- a/rfc_process.md
+++ b/rfc_process.md
@@ -4,7 +4,7 @@ The OpenTracing specification consists of a cross-language, abstract interface, 
 In order effect changes to the OpenTracing specification, all interfaces are developed together in a three step process:
 
 * DRAFT: An RFC is drafted to define and justify the desired changes.
-* TEST: A new version of each langauage interface is designed, tested, and released.
+* TEST: A new version of each language interface is designed, tested, and released.
 * ACCEPTED: The abstract interface is versioned to reflect the final changes.
 
 # Proposal Components
@@ -19,7 +19,7 @@ An RFC consists of the following:
 * Historical background.
 * Abstract interface.
 * Use cases.
-* Risk Assesment.
+* Risk Assessment.
 
 An RFC has the following qualities:
 
@@ -48,7 +48,7 @@ A complete release candidate consists of the following:
 * Repository branch containing the new version.
 * Packages for installing the new version.
 * Tracers which bind to the new version.
-* Major instrmentation ported to the new version.
+* Major instrumentation ported to the new version.
 
 # Proposal Lifecycle
 
@@ -78,6 +78,8 @@ Once the draft proposal is finalized, language implementation begins. Language m
 * RFC status changed from `Test` to `Accepted`.
 * Tracking issue for the proposal is closed.
 
-After a quorum of language interfaces have been tested and released, consensus may be reached that a proposal has been finalized. At this point, the abstract interface contained in the `specification.md` document is updated to reflect the final changes, based on the language in the RFC docment and release candidates.
+After a quorum of language interfaces have been tested and released, consensus may be reached that a proposal has been finalized. At this point, the abstract interface contained in the `specification.md` document is updated to reflect the final changes, based on the language in the RFC document and release candidates.
 
-In addition to the specification, the OpenTracing website and other major docmentation efforts are updated at this time to reflect the latest version. Once all work is complete, the tracking issue is closed.
+In addition to the specification, the OpenTracing website and other major documentation efforts are updated at this time to reflect the latest version. Once all work is complete, the tracking issue is closed.
+
+

--- a/rfc_process.md
+++ b/rfc_process.md
@@ -14,7 +14,7 @@ Proposals begin as a single document, written in markdown and committed to the `
 
 An RFC consists of the following:
 
-* Title, status, and author.
+* Proposal name, status, and author.
 * Problem statement.
 * Historical background.
 * Abstract interface.
@@ -34,9 +34,9 @@ Often, a proposal will consist of multiple artifacts, such as GitHub issues, pul
 
 A tracking issue consists of the following:
 
-* Title, status, and author.
-* Short description of the proposal.
-* A link to the committed RFC.
+* Proposal name, status, and author.
+* Short summary or proposal abstract.
+* A link to the RFC.
 * Lists of open issues, PRs, and upcoming deadlines.
 * Links to relevant artifacts, such as release candidates.
 * Links to meetings and other discussion channels.

--- a/rfc_process.md
+++ b/rfc_process.md
@@ -25,7 +25,7 @@ An RFC has the following qualities:
 
 * The issue is clearly defined, and within the scope of the OpenTracing charter.
 * The utility to the OT community is illustrated with concrete use cases. It should be clear not only what will change, but how the new interface is expected to be used.
-* Changes to the abstract interface are clearly defined. Language-specific interfaces will be implemented in a later phase,but the abstract interface must be clear enough that the changes could be ported to many languages without much deviation.
+* Changes to the abstract interface are clearly defined. Language-specific interfaces will be implemented in a later phase, but the abstract interface must be clear enough that the changes could be ported to many languages without much deviation.
 * All expected behavior should be documented, in sufficient detail such that language-specific tests and examples can be generated from the descriptions.
 * Risks, backwards compatibility, and potential for inconsistency are addressed.
 

--- a/rfc_template.md
+++ b/rfc_template.md
@@ -1,9 +1,12 @@
-# 0001: RFC_NAME
+# RFC_NAME
 
 **Current State:** Draft  
 **Author:** GITHUB_HANDLE
 
-The opening section of the RFC is used to define the problem. Any relevant historical background should be included here. The issue must be clearly defined, and within the scope of the OpenTracing charter.
+The opening section of the RFC is used to define the problem. The motivating issue must be clearly defined, and the requested changes must within the scope of the OpenTracing charter.
+
+# Background
+Relevant historical context is summarized here. Since Since OpenTracing is a standardization effort, successful proposals will usually be based on existing academic research and insustry solutions. References to any prior proposals or standardization efforts should also be included.
 
 # Specification Changes
 Changes to the abstract interface must be clearly defined. Language-specific interfaces will be implemented in a later phase, and the abstract interface contained here must be clear enough such that the changes can be ported to many languages without much deviation.

--- a/rfc_template.md
+++ b/rfc_template.md
@@ -1,0 +1,18 @@
+# 0001: RFC_NAME
+
+**Updated:** January 01, 2018  
+**Current State:** Draft  
+**Author:** GITHUB_HANDLE
+
+The opening section of the RFC is used to define the problem. Any relevant historical background should be included here. The issue must be clearly defined, and within the scope of the OpenTracing charter.
+
+# Specification Changes
+Changes to the abstract interface must be clearly defined. Language-specific interfaces will be implemented in a later phase, and the abstract interface contained here must be clear enough such that the changes can be ported to many languages without much deviation.
+
+All expected behavior should be documented, in sufficient detail such that language-specific tests and examples can be generated from the descriptions.
+
+# Use Cases
+Concrete use cases must be provided, in order to guide testing and interface design, and assist reviewers.
+
+# Risk Assesment
+Risks, backwards compatibility, and potential for inconsistency are addressed.

--- a/rfc_template.md
+++ b/rfc_template.md
@@ -1,6 +1,5 @@
 # 0001: RFC_NAME
 
-**Updated:** January 01, 2018  
 **Current State:** Draft  
 **Author:** GITHUB_HANDLE
 

--- a/rfc_template.md
+++ b/rfc_template.md
@@ -14,5 +14,5 @@ All expected behavior should be documented, in sufficient detail such that langu
 # Use Cases
 Concrete use cases must be provided, in order to guide testing and interface design, and assist reviewers.
 
-# Risk Assesment
+# Risk Assessment
 Risks, backwards compatibility, and potential for inconsistency are addressed.


### PR DESCRIPTION
## RFC Proposal
https://github.com/opentracing/specification/blob/tedsuo/rfc-process/rfc_process.md
Defines a more formal versioning process for the OpenTracing specification.

## RFC Template
https://github.com/opentracing/specification/blob/tedsuo/rfc-process/rfc_template.md
To be used for starting proposals.

## Example RFC
https://github.com/opentracing/specification/pull/107 [Trace-Parent Accessors](https://github.com/opentracing/specification/pull/107)
A real change request, done in the format defined within this pull request.

## Inspiration and prior art
* Couchbase: https://github.com/couchbaselabs/sdk-rfcs/
* IETF
* W3C
