### PR TITLE
Remove dash in `Trace-Parent`

### DIFF
--- a/rfc/trace_identifiers.md
+++ b/rfc/trace_identifiers.md
@@ -19,6 +19,7 @@ The `traceparent` header contains the following fields: `version`, `trace-id`, `
 | :---  | :---   | :---    |
 | `trace-id` | 128-bit; 32HEXDIG | The ID of the whole trace forest. If all bytes are 0, the `traceparent` may be ignored. |
 | `span-id`  | 64-bit; 16HEXDIG | The ID of the caller span (parent). If all bytes are 0, the `Traceparent` may be ignored. |
+| `trace-options` | 8-bit; 2HEXDIG | An 8-bit field that controls tracing options such as sampling, trace level etc. These flags are recommendations given by the caller rather than strict rules to follow. Currently only one bit is used. |
 
 ## B3 HTTP Headers
 The [B3 HTTP headers](https://github.com/openzipkin/b3-propagation) are widely adopted, mostly by Zipkin-like tracing systems. The B3 protocol includes `X-B3-TraceId` and `X-B3-SpanId` as required headers, which contain the `TraceId` and `SpanId` values, respectively.

--- a/rfc/trace_identifiers.md
+++ b/rfc/trace_identifiers.md
@@ -13,12 +13,12 @@ Before discussing changes to the OpenTracing specification, it’s worth reviewi
 ## Trace-Context HTTP Headers
 [Trace-Context HTTP headers](https://github.com/w3c/distributed-tracing) are in the process of being standardized via the w3c. The tracing community has voiced strong support in implementing these headers for use in tracing interop.
 
-The `TraceParent` header contains the following fields: `version`, `trace-id`, `span-id`, and `trace-options`.
+The `traceparent` header contains the following fields: `version`, `trace-id`, `span-id`, and `trace-options`.
 
 | field | format | description |
 | :---  | :---   | :---    |
-| `trace-id` | 128-bit; 32HEXDIG | The ID of the whole trace forest. If all bytes are 0, the `TraceParent` may be ignored. |
-| `span-id`  | 64-bit; 16HEXDIG | The ID of the caller span (parent). If all bytes are 0, the `TraceParent` may be ignored. |
+| `trace-id` | 128-bit; 32HEXDIG | The ID of the whole trace forest. If all bytes are 0, the `traceparent` may be ignored. |
+| `span-id`  | 64-bit; 16HEXDIG | The ID of the caller span (parent). If all bytes are 0, the `Traceparent` may be ignored. |
 
 ## B3 HTTP Headers
 The [B3 HTTP headers](https://github.com/openzipkin/b3-propagation) are widely adopted, mostly by Zipkin-like tracing systems. The B3 protocol includes `X-B3-TraceId` and `X-B3-SpanId` as required headers, which contain the `TraceId` and `SpanId` values, respectively.

--- a/rfc/trace_identifiers.md
+++ b/rfc/trace_identifiers.md
@@ -13,12 +13,12 @@ Before discussing changes to the OpenTracing specification, it’s worth reviewi
 ## Trace-Context HTTP Headers
 [Trace-Context HTTP headers](https://github.com/w3c/distributed-tracing) are in the process of being standardized via the w3c. The tracing community has voiced strong support in implementing these headers for use in tracing interop.
 
-The `Trace-Parent` header contains the following fields: `version`, `trace-id`, `span-id`, and `trace-options`.
+The `TraceParent` header contains the following fields: `version`, `trace-id`, `span-id`, and `trace-options`.
 
 | field | format | description |
 | :---  | :---   | :---    |
-| `trace-id` | 128-bit; 32HEXDIG | The ID of the whole trace forest. If all bytes are 0, the `Trace-Parent` may be ignored. |
-| `span-id`  | 64-bit; 16HEXDIG | The ID of the caller span (parent). If all bytes are 0, the `Trace-Parent` may be ignored. |
+| `trace-id` | 128-bit; 32HEXDIG | The ID of the whole trace forest. If all bytes are 0, the `TraceParent` may be ignored. |
+| `span-id`  | 64-bit; 16HEXDIG | The ID of the caller span (parent). If all bytes are 0, the `TraceParent` may be ignored. |
 
 ## B3 HTTP Headers
 The [B3 HTTP headers](https://github.com/openzipkin/b3-propagation) are widely adopted, mostly by Zipkin-like tracing systems. The B3 protocol includes `X-B3-TraceId` and `X-B3-SpanId` as required headers, which contain the `TraceId` and `SpanId` values, respectively.
@@ -47,7 +47,8 @@ A string is preferred over other formats for the following reasons:
 ## Alternate Formats
 In some cases, additional formats may be appropriate, if a language supports multiple common transport formats. Rather than manually converting the string value to another format, an additional accessors could be added to allow the tracer to do the conversion.
 
-If tracing systems converge on common in-memory formats for Trace-Context identifiers, accessors may be added for those formats as well.
+If tracing systems converge on common in-memory formats for Trace-Context identifiers, accessors may be added for those 
+formats as well.
 
 ## Backwards Compatibility and Optional Support
 The OpenTracing specification does not currently require trace and span identifiers. To continue support for existing tracers, the empty string value can be returned when no ID has been set.


### PR DESCRIPTION
Both the [repo](https://github.com/w3c/distributed-tracing/blob/master/trace_context/HTTP_HEADER_FORMAT.md) and [W3C Spec](https://w3c.github.io/distributed-tracing/report-trace-context.html) for Distributed Tracing describe the `traceparent` header without dashes.