### PR TITLE
Set the scope_manager RFC to Test.

### DIFF
--- a/rfc/scope_manager.md
+++ b/rfc/scope_manager.md
@@ -1,6 +1,6 @@
 # Scope Manager
 
-**Current State:** Draft  
+**Current State:** Test
 **Author:** [carlosalberto](https://github.com/carlosalberto)
 
 In the OpenTracing specification, under the "Optional API Elements" section, it is mentioned languages may choose to provide utilities to pass an active **Span** around a single process.

--- a/rfc/scope_manager.md
+++ b/rfc/scope_manager.md
@@ -23,15 +23,17 @@ New `ScopeManager` and `Scope` interfaces are added to the specification, and th
 
 The `ScopeManager` interface allows setting the active `Span` in a call-context storage section, and has the following members:
 
-* **activate**, capability to set the specified `Span` as the active one for the current call-context, returning a `Scope` containing it. A required boolean parameter **finish span on close** will mark whether the returned `Scope` should, upon deactivation, **finish** the contained `Span`.
-* **active**, the `Scope` containing the current active `Span` if any, or else null/nothing.
+* **activate**, capability to set the specified `Span` as the active one for the current call-context, returning a `Scope` to later end its active period.
+  An **optional** feature to optionally **finish** the `Span` upon `Scope` deactivation may be provided, depending on its suitability for the language. It would require a boolean parameter **finish span on close**.
+* **active Span**, the `Span` that is currently active, if any, or else null/nothing.
+* **active**, the corresponding `Scope` for the current active `Span` if any, or else null/nothing.
 
 ## Scope
 
 The `Scope` interface acts as a container of the active `Span` for the current-call context, and has the following members:
 
-* **span**, the contained active `Span` for this call-context. It will never be null/nothing.
 * **close**, marking the end of the active period for the current `Span`, and optionally **finishing** it. Calling it more than once leads to undefined behavior.
+* **span** (optional), the related active `Span` for this call-context, depending on its suitability for the language. It will never be null/nothing.
 
 If the language supports some kind of auto finishing statement (such as `try` for Java, or `with` for Python), `Scope` should adhere to such convention. Additionally, `Scope` is not guaranteed to be thread-safe.
 
@@ -40,7 +42,8 @@ If the language supports some kind of auto finishing statement (such as `try` fo
 The `Tracer` interface will be extended with:
 
 * **scope manager**, the `ScopeManager` tracking the active `Span` for this instance.
-* **start active span**, a new behavior for starting a new `Span`, which will be automatically marked as active for the current call-context. It will return a `Scope`. A parameter **finish span on close** will mark whether the `Scope` should, upon deactivation, **finish** the contained `Span`. A default value for this parameter may be provided, depending on the suitability for the language and its use cases.
+* **start active span** (optional), a new behavior for starting a new `Span`, which will be automatically marked as active for the current call-context. It will return a `Scope`.
+  An **optional** feature to optionally finish `Span` upon `Scope` deactivation may be provided, depending on its suitability for the language. It would require a boolean parameter **finish span on close**. A default value for this parameter may be provided, depending again on the suitability for the language and its use cases.
 * Both **start span** and **start active span** will implicitly use any active `Span` as the parent for newly created `Span`s (with a `ChildOf` relationship), unless the parent is explicitly specified, or (the new) **ignore active span** parameter is specified (in which case the resulting `Span` will have no parent at all).
 
 # Use Cases

--- a/specification.md
+++ b/specification.md
@@ -139,7 +139,7 @@ Formally, it has the following capabilities:
 
 There should be no parameters.
 
-**Returns** the used `ScopeManager` instance to set and retrieve the active `Span`. The mentioned active instance is additinaly used by default as the implicit parent for newly created `Span`s, in case no **references** were provided.
+**Returns** the used `ScopeManager` instance to set and retrieve the active `Scope` and `Span`. The mentioned active instance is additinaly used by default as the implicit parent for newly created `Span`s, in case no **references** were provided.
 
 #### Start a new `Span`
 
@@ -168,7 +168,7 @@ Optional parameters
 
 This operation does the same as **Start a new `Span`**, in addition to setting the newly created `Span` as the active instance for the current thread or execution unit through the contained `ScopeManager` instance.
 
-It is **highly** encouraged that the name for this operation includes a `Scope` sufix, in order to make clear the type of the returned instance.
+It is **highly** encouraged that language implementations (methods or fields) of this operation include a `Scope` suffix, in order to make clear the type of the returned instance.
 
 Parameters are the same as **Start a new Span**, with the addition of:
 
@@ -279,7 +279,7 @@ This is modeled in different ways depending on the language, but semantically th
 
 ### `ScopeManager`
 
-The `ScopeManager` interface sets and retrieves the active `Span`, working along the `Scope` container interface.
+The `ScopeManager` interface sets and retrieves the active `Scope` and `Span`.
 Formally, it has the following capabilities:
 
 #### Activate a `Span`
@@ -301,7 +301,7 @@ There should be no parameters.
 
 ### `Scope`
 
-The `Scope` interface acts as a simple container for the active `Span`,and it not guaranteed to be thread-safe. It has the following capabilities:
+The `Scope` interface acts as a simple container for the active `Span`,and it is not guaranteed to be thread-safe. It has the following capabilities:
 
 #### Retrieve the contained `Span`
 


### PR DESCRIPTION
Initial take on the `ScopeManager` RFC.

Notes:

* Used 'thread or execution unit' in order to abstract things such as coroutines.
* Mentioned `Scope`s are not thread-safe.
* Mentioned the `null` the value (it hadn't been mentioned before in the Specification).
* Light take on the recent `start_active_span()` vs `start_active_scope()` debate.
* Used `ScopeManager.active()` (as opposed to `ScopeManager.activeSpan()`). Prone to change based on further discussion.

Please provide feedback ;)

@tedsuo @palazzem @pavolloffay @pglombardo @yurishkuro @jpkrohling @indrekj @mwear @felixbarny @cwe1ss @adriancole