### PR TITLE
Swap Jonathan Kaldor for Michael Bevilacqua-Linn on OTIAB

### DIFF
--- a/project_organization.md
+++ b/project_organization.md
@@ -42,7 +42,7 @@ The current OpenTracing Industrial Advisory Board is as follows (in alphabetical
 - Brian Hanafee ([@bhanafee](https://github.com/bhanafee)): Wells Fargo
 - Bruce Wong ([@brucemwong](https://github.com/brucemwong)): StitchFix
 - Dimitrios Kouzis-Loukas ([@lookfwd](https://github.com/lookfwd)): Bloomberg
-- Jonathan Kaldor ([@jmkaldor](https://github.com/jmkaldor)): Facebook
+- Michael Bevilacqua-Linn ([@mblinn](https://github.com/mblinn)): Facebook
 - Jonathan Mace ([@jonathanmace](https://github.com/jonathanmace)): Brown University / PivotTracing
 - Stephen Day ([@stevvooe](https://github.com/stevvooe)): Docker
 - Suman Karumuri ([@mansu](https://github.com/mansu)): Pinterest


### PR DESCRIPTION
Jonathan has moved to non-tracing project and nominated Michael as Facebook representative to OTIAB.

cc @opentracing/otiab @opentracing/otsc  @mblinn 